### PR TITLE
Feature

### DIFF
--- a/bin/netcap
+++ b/bin/netcap
@@ -498,13 +498,14 @@ sub main
 			}else{
 				print STDERR "|--> suppress traffic from stdout stream\n";
 			}
-			print STDERR "|--> ensure traffic matches: \"$arg{regex_cap}\" (regex filter)\n" 
+			print STDERR "|--> match traffic regex to: \"$arg{regex_cap}\"\n" 
 				if($arg{do_regex_cap});
 			if($arg{do_compile_filter}){
-				print STDERR "|--> ensure traffic matches: \"$arg{compile_filter}\" (compile filter)\n";
-				my $optimize = ($arg{compile_filter_optimize}) ? "invoke" : "avoid";
-				print STDERR "|--> $optimize optimization of compiled filter\n";
+				my $optimize = ($arg{compile_filter_optimize}) ? "optimized" : "not optimized";
+				print STDERR "|--> match traffic compile filter to: \"$arg{compile_filter}\" ($optimize)\n";
 			}
+			print STDERR "|--> capture $arg{snaplen} byte(s)/packet\n";
+			print STDERR "|--> set a read timeout of $arg{read_timeout} millisecond(s)\n";
 			if($arg{promiscuous}){
 				print STDERR "|--> listen in promiscuous mode\n";
 			}else{
@@ -872,25 +873,14 @@ sub capture
 	
 	#create packet capture descriptor
 	print STDERR "\n$arg->{name}:\n";
-	print STDERR "|--> Running as pid: $pid\n";
-	print STDERR "|--> Capturing $arg->{snaplen} byte(s)/packet...\n";
-	print STDERR "|--> Read timeout of $arg->{read_timeout} millisecond(s)\n";
-	print STDERR "|--> Binding to interface: $arg->{interface}... ";
+	print STDERR "|--> running as pid: $pid\n";
+	print STDERR "|--> binding to interface: $arg->{interface}... ";
 	create_device($arg->{interface}, \$netmask, $arg->{snaplen}, 
 		$arg->{promiscuous}, $arg->{read_timeout}, \$pcap);
 	print STDERR "success.\n";
 	
 	#capturing
-	if($arg->{promiscuous}){
-		print STDERR "|--> Listening (promiscuous mode = Yes)...\n";
-	}else{
-		print STDERR "|--> Listening (promiscuous mode = No)...\n";
-	}
-	print STDERR "\nNote:\n";
-	print STDERR "|--> To stop capturing at any time, press 'ctrl + c'\n";
-	print STDERR "|--> You can also send a TERM or INT signal to pid: $pid\n";
-	print STDERR "|--> To display current capture progress stats, send a USR1\n";
-	print STDERR "|--> signal to pid: $pid\n\n";
+	print STDERR "|--> listening...\n\n";
 	
 	for(;;)
 	{
@@ -937,54 +927,80 @@ sub capture
 			if($arg->{do_unique}){
 				if($arg->{do_stdout} && ! exists($data{$traffic})){
 					if($arg->{do_packet_detail}){
-						print "$traffic|$hdr|$tcp_flag";
+						print "TRAFFIC|$traffic|HEADER|$hdr|FLAG|$tcp_flag";
 					}else{
-						print "$traffic";
+						print "TRAFFIC|$traffic";
 					}
 					if($arg->{do_geo_src}){
 						 if($arg->{geo_src_info_flag} == 1){
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_src{continent_code}, $g_loc_src{country_code3}, 
-								$g_loc_src{country_name}, $g_loc_src{city}, 
-								$g_loc_src{region_name}, $g_loc_src{postal_code}, 
-								$g_loc_src{latitude}, $g_loc_src{longitude}, 
-								$g_loc_src{time_zone}, $g_loc_src{area_code}, 
-								$g_loc_src{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"SRC_CONTINENT_CODE", $g_loc_src{continent_code}, 
+								"SRC_COUNTRY_CODE3", $g_loc_src{country_code3}, 
+								"SRC_COUNTRY_NAME", $g_loc_src{country_name}, 
+								"SRC_CITY", $g_loc_src{city},
+								"SRC_REGION_NAME", $g_loc_src{region_name}, 
+								"SRC_POSTAL_CODE", $g_loc_src{postal_code}, 
+								"SRC_LATITUDE", $g_loc_src{latitude}, 
+								"SRC_LONGITUDE", $g_loc_src{longitude},
+								"SRC_TIME_ZONE", $g_loc_src{time_zone}, 
+								"SRC_AREA_CODE", $g_loc_src{area_code}, 
+								"SRC_METRO_CODE", $g_loc_src{metro_code});
 						}elsif($arg->{geo_src_info_flag} == 2){
-							printf("|%s|%s|%s|%s", $g_ip4_src[0], $g_ip4_src[1], 
-								$g_ip4_src[2], $g_ip4_src[3]);
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "SRC_IP4_MIN", $g_ip4_src[0], 
+								"SRC_IP4_MAX", $g_ip4_src[1], "SRC_IP4_MASK", $g_ip4_src[2], 
+								"SRC_IP4_CIDR", $g_ip4_src[3]);
 						}else{
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_src{continent_code}, $g_loc_src{country_code3}, 
-								$g_loc_src{country_name}, $g_loc_src{city}, 
-								$g_loc_src{region_name}, $g_loc_src{postal_code}, 
-								$g_loc_src{latitude}, $g_loc_src{longitude}, 
-								$g_loc_src{time_zone}, $g_loc_src{area_code}, 
-								$g_loc_src{metro_code}, $g_ip4_src[0], $g_ip4_src[1], 
-								$g_ip4_src[2], $g_ip4_src[3]);	
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"SRC_CONTINENT_CODE", $g_loc_src{continent_code}, 
+								"SRC_COUNTRY_CODE3", $g_loc_src{country_code3}, 
+								"SRC_COUNTRY_NAME", $g_loc_src{country_name}, 
+								"SRC_CITY", $g_loc_src{city},
+								"SRC_REGION_NAME", $g_loc_src{region_name}, 
+								"SRC_POSTAL_CODE", $g_loc_src{postal_code}, 
+								"SRC_LATITUDE", $g_loc_src{latitude}, 
+								"SRC_LONGITUDE", $g_loc_src{longitude},
+								"SRC_TIME_ZONE", $g_loc_src{time_zone}, 
+								"SRC_AREA_CODE", $g_loc_src{area_code}, 
+								"SRC_METRO_CODE", $g_loc_src{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "SRC_IP4_MIN", $g_ip4_src[0], 
+								"SRC_IP4_MAX", $g_ip4_src[1], "SRC_IP4_MASK", $g_ip4_src[2], 
+								"SRC_IP4_CIDR", $g_ip4_src[3]);
 						}
 					}
 					if($arg->{do_geo_dst}){
-						 if($arg->{geo_dst_info_flag} == 1){
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_dst{continent_code}, $g_loc_dst{country_code3}, 
-								$g_loc_dst{country_name}, $g_loc_dst{city}, 
-								$g_loc_dst{region_name}, $g_loc_dst{postal_code}, 
-								$g_loc_dst{latitude}, $g_loc_dst{longitude}, 
-								$g_loc_dst{time_zone}, $g_loc_dst{area_code}, 
-								$g_loc_dst{metro_code});
+						if($arg->{geo_dst_info_flag} == 1){
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"DST_CONTINENT_CODE", $g_loc_dst{continent_code}, 
+								"DST_COUNTRY_CODE3", $g_loc_dst{country_code3}, 
+								"DST_COUNTRY_NAME", $g_loc_dst{country_name}, 
+								"DST_CITY", $g_loc_dst{city},
+								"DST_REGION_NAME", $g_loc_dst{region_name}, 
+								"DST_POSTAL_CODE", $g_loc_dst{postal_code}, 
+								"DST_LATITUDE", $g_loc_dst{latitude}, 
+								"DST_LONGITUDE", $g_loc_dst{longitude},
+								"DST_TIME_ZONE", $g_loc_dst{time_zone}, 
+								"DST_AREA_CODE", $g_loc_dst{area_code}, 
+								"DST_METRO_CODE", $g_loc_dst{metro_code});
 						}elsif($arg->{geo_dst_info_flag} == 2){
-							printf("|%s|%s|%s|%s", $g_ip4_dst[0], $g_ip4_dst[1], 
-								$g_ip4_dst[2], $g_ip4_dst[3])
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "DST_IP4_MIN", $g_ip4_dst[0], 
+								"DST_IP4_MAX", $g_ip4_dst[1], "DST_IP4_MASK", $g_ip4_dst[2], 
+								"DST_IP4_CIDR", $g_ip4_dst[3]);
 						}else{
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_dst{continent_code}, $g_loc_dst{country_code3}, 
-								$g_loc_dst{country_name}, $g_loc_dst{city}, 
-								$g_loc_dst{region_name}, $g_loc_dst{postal_code}, 
-								$g_loc_dst{latitude}, $g_loc_dst{longitude}, 
-								$g_loc_dst{time_zone}, $g_loc_dst{area_code}, 
-								$g_loc_dst{metro_code}, $g_ip4_dst[0], $g_ip4_dst[1], 
-								$g_ip4_dst[2], $g_ip4_dst[3]);	
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"DST_CONTINENT_CODE", $g_loc_dst{continent_code}, 
+								"DST_COUNTRY_CODE3", $g_loc_dst{country_code3}, 
+								"DST_COUNTRY_NAME", $g_loc_dst{country_name}, 
+								"DST_CITY", $g_loc_dst{city},
+								"DST_REGION_NAME", $g_loc_dst{region_name}, 
+								"DST_POSTAL_CODE", $g_loc_dst{postal_code}, 
+								"DST_LATITUDE", $g_loc_dst{latitude}, 
+								"DST_LONGITUDE", $g_loc_dst{longitude},
+								"DST_TIME_ZONE", $g_loc_dst{time_zone}, 
+								"DST_AREA_CODE", $g_loc_dst{area_code}, 
+								"DST_METRO_CODE", $g_loc_dst{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "DST_IP4_MIN", $g_ip4_dst[0], 
+								"DST_IP4_MAX", $g_ip4_dst[1], "DST_IP4_MASK", $g_ip4_dst[2], 
+								"DST_IP4_CIDR", $g_ip4_dst[3]);
 						}
 					}
 					print "\n";
@@ -993,54 +1009,80 @@ sub capture
 			}else{
 				if($arg->{do_stdout}){
 					if($arg->{do_packet_detail}){
-						print "$traffic|$hdr|$tcp_flag\n";
+						print "TRAFFIC|$traffic|HEADER|$hdr|FLAG|$tcp_flag";
 					}else{
-						print "$traffic\n";
+						print "TRAFFIC|$traffic";
 					}
 					if($arg->{do_geo_src}){
-						if($arg->{geo_src_info_flag} == 1){
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_src{continent_code}, $g_loc_src{country_code3}, 
-								$g_loc_src{country_name}, $g_loc_src{city}, 
-								$g_loc_src{region_name}, $g_loc_src{postal_code}, 
-								$g_loc_src{latitude}, $g_loc_src{longitude}, 
-								$g_loc_src{time_zone}, $g_loc_src{area_code}, 
-								$g_loc_src{metro_code});
+						 if($arg->{geo_src_info_flag} == 1){
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"SRC_CONTINENT_CODE", $g_loc_src{continent_code}, 
+								"SRC_COUNTRY_CODE3", $g_loc_src{country_code3}, 
+								"SRC_COUNTRY_NAME", $g_loc_src{country_name}, 
+								"SRC_CITY", $g_loc_src{city},
+								"SRC_REGION_NAME", $g_loc_src{region_name}, 
+								"SRC_POSTAL_CODE", $g_loc_src{postal_code}, 
+								"SRC_LATITUDE", $g_loc_src{latitude}, 
+								"SRC_LONGITUDE", $g_loc_src{longitude},
+								"SRC_TIME_ZONE", $g_loc_src{time_zone}, 
+								"SRC_AREA_CODE", $g_loc_src{area_code}, 
+								"SRC_METRO_CODE", $g_loc_src{metro_code});
 						}elsif($arg->{geo_src_info_flag} == 2){
-							printf("|%s|%s|%s|%s", $g_ip4_src[0], $g_ip4_src[1], 
-								$g_ip4_src[2], $g_ip4_src[3]);
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "SRC_IPv4_MIN", $g_ip4_src[0], 
+								"SRC_IPv4_MAX", $g_ip4_src[1], "SRC_IPV4_MASK", $g_ip4_src[2], 
+								"SRC_IPv4_CIDR", $g_ip4_src[3]);
 						}else{
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_src{continent_code}, $g_loc_src{country_code3}, 
-								$g_loc_src{country_name}, $g_loc_src{city}, 
-								$g_loc_src{region_name}, $g_loc_src{postal_code}, 
-								$g_loc_src{latitude}, $g_loc_src{longitude}, 
-								$g_loc_src{time_zone}, $g_loc_src{area_code}, 
-								$g_loc_src{metro_code}, $g_ip4_src[0], $g_ip4_src[1], 
-								$g_ip4_src[2], $g_ip4_src[3]);	
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"SRC_CONTINENT_CODE", $g_loc_src{continent_code}, 
+								"SRC_COUNTRY_CODE3", $g_loc_src{country_code3}, 
+								"SRC_COUNTRY_NAME", $g_loc_src{country_name}, 
+								"SRC_CITY", $g_loc_src{city},
+								"SRC_REGION_NAME", $g_loc_src{region_name}, 
+								"SRC_POSTAL_CODE", $g_loc_src{postal_code}, 
+								"SRC_LATITUDE", $g_loc_src{latitude}, 
+								"SRC_LONGITUDE", $g_loc_src{longitude},
+								"SRC_TIME_ZONE", $g_loc_src{time_zone}, 
+								"SRC_AREA_CODE", $g_loc_src{area_code}, 
+								"SRC_METRO_CODE", $g_loc_src{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "SRC_IPv4_MIN", $g_ip4_src[0], 
+								"SRC_IPv4_MAX", $g_ip4_src[1], "SRC_IPV4_MASK", $g_ip4_src[2], 
+								"SRC_IPv4_CIDR", $g_ip4_src[3]);
 						}
 					}
 					if($arg->{do_geo_dst}){
 						if($arg->{geo_dst_info_flag} == 1){
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_dst{continent_code}, $g_loc_dst{country_code3}, 
-								$g_loc_dst{country_name}, $g_loc_dst{city}, 
-								$g_loc_dst{region_name}, $g_loc_dst{postal_code}, 
-								$g_loc_dst{latitude}, $g_loc_dst{longitude}, 
-								$g_loc_dst{time_zone}, $g_loc_dst{area_code}, 
-								$g_loc_dst{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"DST_CONTINENT_CODE", $g_loc_dst{continent_code}, 
+								"DST_COUNTRY_CODE3", $g_loc_dst{country_code3}, 
+								"DST_COUNTRY_NAME", $g_loc_dst{country_name}, 
+								"DST_CITY", $g_loc_dst{city},
+								"DST_REGION_NAME", $g_loc_dst{region_name}, 
+								"DST_POSTAL_CODE", $g_loc_dst{postal_code}, 
+								"DST_LATITUDE", $g_loc_dst{latitude}, 
+								"DST_LONGITUDE", $g_loc_dst{longitude},
+								"DST_TIME_ZONE", $g_loc_dst{time_zone}, 
+								"DST_AREA_CODE", $g_loc_dst{area_code}, 
+								"DST_METRO_CODE", $g_loc_dst{metro_code});
 						}elsif($arg->{geo_dst_info_flag} == 2){
-							printf("|%s|%s|%s|%s", $g_ip4_dst[0], $g_ip4_dst[1], 
-								$g_ip4_dst[2], @g_ip4_dst[3])
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "DST_IPv4_MIN", $g_ip4_dst[0], 
+								"DST_IPv4_MAX", $g_ip4_dst[1], "DST_IPV4_MASK", $g_ip4_dst[2], 
+								"DST_IPv4_CIDR", $g_ip4_dst[3]);
 						}else{
-							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
-								$g_loc_dst{continent_code}, $g_loc_dst{country_code3}, 
-								$g_loc_dst{country_name}, $g_loc_dst{city}, 
-								$g_loc_dst{region_name}, $g_loc_dst{postal_code}, 
-								$g_loc_dst{latitude}, $g_loc_dst{longitude}, 
-								$g_loc_dst{time_zone}, $g_loc_dst{area_code}, 
-								$g_loc_dst{metro_code}, $g_ip4_dst[0], $g_ip4_dst[1], 
-								$g_ip4_dst[2], $g_ip4_dst[3]);	
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s", 
+								"DST_CONTINENT_CODE", $g_loc_dst{continent_code}, 
+								"DST_COUNTRY_CODE3", $g_loc_dst{country_code3}, 
+								"DST_COUNTRY_NAME", $g_loc_dst{country_name}, 
+								"DST_CITY", $g_loc_dst{city},
+								"DST_REGION_NAME", $g_loc_dst{region_name}, 
+								"DST_POSTAL_CODE", $g_loc_dst{postal_code}, 
+								"DST_LATITUDE", $g_loc_dst{latitude}, 
+								"DST_LONGITUDE", $g_loc_dst{longitude},
+								"DST_TIME_ZONE", $g_loc_dst{time_zone}, 
+								"DST_AREA_CODE", $g_loc_dst{area_code}, 
+								"DST_METRO_CODE", $g_loc_dst{metro_code});
+							printf("|%s|%s|%s|%s|%s|%s|%s|%s", "DST_IPv4_MIN", $g_ip4_dst[0], 
+								"DST_IPv4_MAX", $g_ip4_dst[1], "DST_IPV4_MASK", $g_ip4_dst[2], 
+								"DST_IPv4_CIDR", $g_ip4_dst[3]);
 						}
 					}
 					print "\n";
@@ -1252,77 +1294,77 @@ sub geo_lookup
 		if($ip =~ m/^((10\.\d{1,3}\.\d{1,3}\.\d{1,3}) |
 					(172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}) |
 					(192\.168\.\d{1,3}\.\d{1,3}))$/x){
-			$g_loc->{continent_code} = "PU_continent_code";
-			$g_loc->{country_code3} = "PU_country_code3";
-			$g_loc->{country_name} = "PU_country_name";
-			$g_loc->{city} = "PU_city";
-			$g_loc->{region_name} = "PU_region_name";
-			$g_loc->{postal_code} = "PU_postal_code";
-			$g_loc->{latitude} = "PU_latitude";
-			$g_loc->{longitude} = "PU_longitude";
-			$g_loc->{time_zone} = "PU_time_zone";
-			$g_loc->{area_code} = "PU_area_code";
-			$g_loc->{metro_code} = "PU_metro_code";
+			$g_loc->{continent_code} = "PU_NULL";
+			$g_loc->{country_code3} = "PU_NULL";
+			$g_loc->{country_name} = "PU_NULL";
+			$g_loc->{city} = "PU_NULL";
+			$g_loc->{region_name} = "PU_NULL";
+			$g_loc->{postal_code} = "PU_NULL";
+			$g_loc->{latitude} = "PU_NULL";
+			$g_loc->{longitude} = "PU_NULL";
+			$g_loc->{time_zone} = "PU_NULL";
+			$g_loc->{area_code} = "PU_NULL";
+			$g_loc->{metro_code} = "PU_NULL";
 		}elsif($ip =~ m/^(22[4-9]|23[0-9])\.\d{1,3}\.\d{1,3}\.\d{1,3}$/){	
-			$g_loc->{continent_code} = "MC_continent_code";
-			$g_loc->{country_code3} = "MC_country_code3";
-			$g_loc->{country_name} = "MC_country_name";
-			$g_loc->{city} = "MC_city";
-			$g_loc->{region_name} = "MC_region_name";
-			$g_loc->{postal_code} = "MC_postal_code";
-			$g_loc->{latitude} = "MC_latitude";
-			$g_loc->{longitude} = "MC_longitude";
-			$g_loc->{time_zone} = "MC_time_zone";
-			$g_loc->{area_code} = "MC_area_code";
-			$g_loc->{metro_code} = "MC_metro_code";
+			$g_loc->{continent_code} = "MC_NULL";
+			$g_loc->{country_code3} = "MC_NULL";
+			$g_loc->{country_name} = "MC_NULL";
+			$g_loc->{city} = "MC_NULL";
+			$g_loc->{region_name} = "MC_NULL";
+			$g_loc->{postal_code} = "MC_NULL";
+			$g_loc->{latitude} = "MC_NULL";
+			$g_loc->{longitude} = "MC_NULL";
+			$g_loc->{time_zone} = "MC_NULL";
+			$g_loc->{area_code} = "MC_NULL";
+			$g_loc->{metro_code} = "MC_NULL";
 		}elsif($ip =~ m/^255\.255\.255\.255$/){
-			$g_loc->{continent_code} = "BC_continent_code";
-			$g_loc->{country_code3} = "BC_country_code3";
-			$g_loc->{country_name} = "BC_country_name";
-			$g_loc->{city} = "BC_city";
-			$g_loc->{region_name} = "BC_region_name";
-			$g_loc->{postal_code} = "BC_postal_code";
-			$g_loc->{latitude} = "BC_latitude";
-			$g_loc->{longitude} = "BC_longitude";
-			$g_loc->{time_zone} = "BC_time_zone";
-			$g_loc->{area_code} = "BC_area_code";
-			$g_loc->{metro_code} = "BC_metro_code";
+			$g_loc->{continent_code} = "BC_NULL";
+			$g_loc->{country_code3} = "BC_NULL";
+			$g_loc->{country_name} = "BC_NULL";
+			$g_loc->{city} = "BC_NULL";
+			$g_loc->{region_name} = "BC_NULL";
+			$g_loc->{postal_code} = "BC_NULL";
+			$g_loc->{latitude} = "BC_NULL";
+			$g_loc->{longitude} = "BC_NULL";
+			$g_loc->{time_zone} = "BC_NULL";
+			$g_loc->{area_code} = "BC_NULL";
+			$g_loc->{metro_code} = "BC_NULL";
 		}elsif($ip =~ m/^169\.254\.\d{1,3}\.\d{1,3}$/){
-			$g_loc->{continent_code} = "AC_continent_code";
-			$g_loc->{country_code3} = "AC_country_code3";
-			$g_loc->{country_name} = "AC_country_name";
-			$g_loc->{city} = "AC_city";
-			$g_loc->{region_name} = "AC_region_name";
-			$g_loc->{postal_code} = "AC_postal_code";
-			$g_loc->{latitude} = "AC_latitude";
-			$g_loc->{longitude} = "AC_longitude";
-			$g_loc->{time_zone} = "AC_time_zone";
-			$g_loc->{area_code} = "AC_area_code";
-			$g_loc->{metro_code} = "AC_metro_code";
+			$g_loc->{continent_code} = "AC_NULL";
+			$g_loc->{country_code3} = "AC_NULL";
+			$g_loc->{country_name} = "AC_NULL";
+			$g_loc->{city} = "AC_NULL";
+			$g_loc->{region_name} = "AC_NULL";
+			$g_loc->{postal_code} = "AC_NULL";
+			$g_loc->{latitude} = "AC_NULL";
+			$g_loc->{longitude} = "AC_NULL";
+			$g_loc->{time_zone} = "AC_NULL";
+			$g_loc->{area_code} = "AC_NULL";
+			$g_loc->{metro_code} = "AC_NULL";
 		}elsif($ip =~ m/^127.\d{1,3}\.\d{1,3}\.\d{1,3}$/){
-			$g_loc->{continent_code} = "LB_continent_code";
-			$g_loc->{country_code3} = "LB_country_code3";
-			$g_loc->{country_name} = "LB_country_name";
-			$g_loc->{city} = "LB_city";
-			$g_loc->{region_name} = "LB_region_name";
-			$g_loc->{postal_code} = "LB_postal_code";
-			$g_loc->{latitude} = "LB_latitude";
-			$g_loc->{longitude} = "LB_longitude";
-			$g_loc->{time_zone} = "LB_time_zone";
-			$g_loc->{area_code} = "LB_area_code";
-			$g_loc->{metro_code} = "LB_metro_code";
+			$g_loc->{continent_code} = "LB_NULL";
+			$g_loc->{country_code3} = "LB_NULL";
+			$g_loc->{country_name} = "LB_NULL";
+			$g_loc->{city} = "LB_NULL";
+			$g_loc->{region_name} = "LB_NULL";
+			$g_loc->{postal_code} = "LB_NULL";
+			$g_loc->{latitude} = "LB_NULL";
+			$g_loc->{longitude} = "LB_NULL";
+			$g_loc->{time_zone} = "LB_NULL";
+			$g_loc->{area_code} = "LB_NULL";
+			$g_loc->{metro_code} = "LB_NULL";
 		}else{
-			$g_loc->{continent_code} = ($rec->{continent_code}) ? $rec->{continent_code} : "NULL";
-			$g_loc->{country_code3} = ($rec->{country_code3}) ? $rec->{country_code3} : "NULL";
-			$g_loc->{country_name} = ($rec->{country_name}) ? $rec->{country_name} : "NULL";
-			$g_loc->{city} = ($rec->{city}) ? $rec->{city} : "NULL";
-			$g_loc->{region_name} = ($rec->{region_name}) ? $rec->{region_name} : "NULL";
-			$g_loc->{postal_code} = ($rec->{postal_code}) ? $rec->{postal_code} : "NULL";
-			$g_loc->{latitude} = ($rec->{latitude}) ? $rec->{latitude} : "NULL";
-			$g_loc->{longitude} = ($rec->{longitude}) ? $rec->{longitude} : "NULL";
-			$g_loc->{time_zone} = ($rec->time_zone) ? $rec->time_zone : "NULL";
-			$g_loc->{area_code} = ($rec->{area_code}) ? $rec->{area_code} : "NULL";
-			$g_loc->{metro_code} = ($rec->{metro_code}) ? $rec->{metro_code} : "NULL";
+			$g_loc->{continent_code} = ($rec->{continent_code}) ? $rec->{continent_code} : "GEO_NULL";
+			$g_loc->{country_code3} = ($rec->{country_code3}) ? $rec->{country_code3} : "GEO_NULL";
+			$g_loc->{country_name} = ($rec->{country_name}) ? $rec->{country_name} : "GEO_NULL";
+			$g_loc->{city} = ($rec->{city}) ? $rec->{city} : "GEO_NULL";
+			$g_loc->{region_name} = ($rec->{region_name}) ? $rec->{region_name} : "GEO_NULL";
+			$g_loc->{postal_code} = ($rec->{postal_code}) ? $rec->{postal_code} : "GEO_NULL";
+			$g_loc->{latitude} = ($rec->{latitude}) ? $rec->{latitude} : "GEO_NULL";
+			$g_loc->{longitude} = ($rec->{longitude}) ? $rec->{longitude} : "GEO_NULL";
+			$g_loc->{time_zone} = ($rec->time_zone) ? $rec->time_zone : "GEO_NULL";
+			$g_loc->{area_code} = ($rec->{area_code}) ? $rec->{area_code} : "GEO_NULL";
+			$g_loc->{metro_code} = ($rec->{metro_code}) ? $rec->{metro_code} : "GEO_NULL";
 		}
 	}elsif($g_mask == 2){
 		my ($from, $to) = $gi->range_by_ip($ip);
@@ -1335,77 +1377,77 @@ sub geo_lookup
 		if($ip =~ m/^((10\.\d{1,3}\.\d{1,3}\.\d{1,3}) |
 					(172\.(1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}) |
 					(192\.168\.\d{1,3}\.\d{1,3}))$/x){
-			$g_loc->{continent_code} = "PU_continent_code";
-			$g_loc->{country_code3} = "PU_country_code3";
-			$g_loc->{country_name} = "PU_country_name";
-			$g_loc->{city} = "PU_city";
-			$g_loc->{region_name} = "PU_region_name";
-			$g_loc->{postal_code} = "PU_postal_code";
-			$g_loc->{latitude} = "PU_latitude";
-			$g_loc->{longitude} = "PU_longitude";
-			$g_loc->{time_zone} = "PU_time_zone";
-			$g_loc->{area_code} = "PU_area_code";
-			$g_loc->{metro_code} = "PU_metro_code"
+			$g_loc->{continent_code} = "PU_NULL";
+			$g_loc->{country_code3} = "PU_NULL";
+			$g_loc->{country_name} = "PU_NULL";
+			$g_loc->{city} = "PU_NULL";
+			$g_loc->{region_name} = "PU_NULL";
+			$g_loc->{postal_code} = "PU_NULL";
+			$g_loc->{latitude} = "PU_NULL";
+			$g_loc->{longitude} = "PU_NULL";
+			$g_loc->{time_zone} = "PU_NULL";
+			$g_loc->{area_code} = "PU_NULL";
+			$g_loc->{metro_code} = "PU_NULL";
 		}elsif($ip =~ m/^(22[4-9]|23[0-9])\.\d{1,3}\.\d{1,3}\.\d{1,3}$/){	
-			$g_loc->{continent_code} = "MC_continent_code";
-			$g_loc->{country_code3} = "MC_country_code3";
-			$g_loc->{country_name} = "MC_country_name";
-			$g_loc->{city} = "MC_city";
-			$g_loc->{region_name} = "MC_region_name";
-			$g_loc->{postal_code} = "MC_postal_code";
-			$g_loc->{latitude} = "MC_latitude";
-			$g_loc->{longitude} = "MC_longitude";
-			$g_loc->{time_zone} = "MC_time_zone";
-			$g_loc->{area_code} = "MC_area_code";
-			$g_loc->{metro_code} = "MC_metro_code";
+			$g_loc->{continent_code} = "MC_NULL";
+			$g_loc->{country_code3} = "MC_NULL";
+			$g_loc->{country_name} = "MC_NULL";
+			$g_loc->{city} = "MC_NULL";
+			$g_loc->{region_name} = "MC_NULL";
+			$g_loc->{postal_code} = "MC_NULL";
+			$g_loc->{latitude} = "MC_NULL";
+			$g_loc->{longitude} = "MC_NULL";
+			$g_loc->{time_zone} = "MC_NULL";
+			$g_loc->{area_code} = "MC_NULL";
+			$g_loc->{metro_code} = "MC_NULL";
 		}elsif($ip =~ m/^255\.255\.255\.255$/){
-			$g_loc->{continent_code} = "BC_continent_code";
-			$g_loc->{country_code3} = "BC_country_code3";
-			$g_loc->{country_name} = "BC_country_name";
-			$g_loc->{city} = "BC_city";
-			$g_loc->{region_name} = "BC_region_name";
-			$g_loc->{postal_code} = "BC_postal_code";
-			$g_loc->{latitude} = "BC_latitude";
-			$g_loc->{longitude} = "BC_longitude";
-			$g_loc->{time_zone} = "BC_time_zone";
-			$g_loc->{area_code} = "BC_area_code";
-			$g_loc->{metro_code} = "BC_metro_code";
+			$g_loc->{continent_code} = "BC_NULL";
+			$g_loc->{country_code3} = "BC_NULL";
+			$g_loc->{country_name} = "BC_NULL";
+			$g_loc->{city} = "BC_NULL";
+			$g_loc->{region_name} = "BC_NULL";
+			$g_loc->{postal_code} = "BC_NULL";
+			$g_loc->{latitude} = "BC_NULL";
+			$g_loc->{longitude} = "BC_NULL";
+			$g_loc->{time_zone} = "BC_NULL";
+			$g_loc->{area_code} = "BC_NULL";
+			$g_loc->{metro_code} = "BC_NULL";
 		}elsif($ip =~ m/^169\.254\.\d{1,3}\.\d{1,3}$/){
-			$g_loc->{continent_code} = "AC_continent_code";
-			$g_loc->{country_code3} = "AC_country_code3";
-			$g_loc->{country_name} = "AC_country_name";
-			$g_loc->{city} = "AC_city";
-			$g_loc->{region_name} = "AC_region_name";
-			$g_loc->{postal_code} = "AC_postal_code";
-			$g_loc->{latitude} = "AC_latitude";
-			$g_loc->{longitude} = "AC_longitude";
-			$g_loc->{time_zone} = "AC_time_zone";
-			$g_loc->{area_code} = "AC_area_code";
-			$g_loc->{metro_code} = "AC_metro_code";
+			$g_loc->{continent_code} = "AC_NULL";
+			$g_loc->{country_code3} = "AC_NULL";
+			$g_loc->{country_name} = "AC_NULL";
+			$g_loc->{city} = "AC_NULL";
+			$g_loc->{region_name} = "AC_NULL";
+			$g_loc->{postal_code} = "AC_NULL";
+			$g_loc->{latitude} = "AC_NULL";
+			$g_loc->{longitude} = "AC_NULL";
+			$g_loc->{time_zone} = "AC_NULL";
+			$g_loc->{area_code} = "AC_NULL";
+			$g_loc->{metro_code} = "AC_NULL";
 		}elsif($ip =~ m/^127.\d{1,3}\.\d{1,3}\.\d{1,3}$/){
-			$g_loc->{continent_code} = "LB_continent_code";
-			$g_loc->{country_code3} = "LB_country_code3";
-			$g_loc->{country_name} = "LB_country_name";
-			$g_loc->{city} = "LB_city";
-			$g_loc->{region_name} = "LB_region_name";
-			$g_loc->{postal_code} = "LB_postal_code";
-			$g_loc->{latitude} = "LB_latitude";
-			$g_loc->{longitude} = "LB_longitude";
-			$g_loc->{time_zone} = "LB_time_zone";
-			$g_loc->{area_code} = "LB_area_code";
-			$g_loc->{metro_code} = "LB_metro_code";
+			$g_loc->{continent_code} = "LB_NULL";
+			$g_loc->{country_code3} = "LB_NULL";
+			$g_loc->{country_name} = "LB_NULL";
+			$g_loc->{city} = "LB_NULL";
+			$g_loc->{region_name} = "LB_NULL";
+			$g_loc->{postal_code} = "LB_NULL";
+			$g_loc->{latitude} = "LB_NULL";
+			$g_loc->{longitude} = "LB_NULL";
+			$g_loc->{time_zone} = "LB_NULL";
+			$g_loc->{area_code} = "LB_NULL";
+			$g_loc->{metro_code} = "LB_NULL";
 		}else{
-			$g_loc->{continent_code} = ($rec->{continent_code}) ? $rec->{continent_code} : "NULL";
-			$g_loc->{country_code3} = ($rec->{country_code3}) ? $rec->{country_code3} : "NULL";
-			$g_loc->{country_name} = ($rec->{country_name}) ? $rec->{country_name} : "NULL";
-			$g_loc->{city} = ($rec->{city}) ? $rec->{city} : "NULL";
-			$g_loc->{region_name} = ($rec->{region_name}) ? $rec->{region_name} : "NULL";
-			$g_loc->{postal_code} = ($rec->{postal_code}) ? $rec->{postal_code} : "NULL";
-			$g_loc->{latitude} = ($rec->{latitude}) ? $rec->{latitude} : "NULL";
-			$g_loc->{longitude} = ($rec->{longitude}) ? $rec->{longitude} : "NULL";
-			$g_loc->{time_zone} = ($rec->time_zone) ? $rec->time_zone : "NULL";
-			$g_loc->{area_code} = ($rec->{area_code}) ? $rec->{area_code} : "NULL";
-			$g_loc->{metro_code} = ($rec->{metro_code}) ? $rec->{metro_code} : "NULL";
+			$g_loc->{continent_code} = ($rec->{continent_code}) ? $rec->{continent_code} : "GEO_NULL";
+			$g_loc->{country_code3} = ($rec->{country_code3}) ? $rec->{country_code3} : "GEO_NULL";
+			$g_loc->{country_name} = ($rec->{country_name}) ? $rec->{country_name} : "GEO_NULL";
+			$g_loc->{city} = ($rec->{city}) ? $rec->{city} : "GEO_NULL";
+			$g_loc->{region_name} = ($rec->{region_name}) ? $rec->{region_name} : "GEO_NULL";
+			$g_loc->{postal_code} = ($rec->{postal_code}) ? $rec->{postal_code} : "GEO_NULL";
+			$g_loc->{latitude} = ($rec->{latitude}) ? $rec->{latitude} : "GEO_NULL";
+			$g_loc->{longitude} = ($rec->{longitude}) ? $rec->{longitude} : "GEO_NULL";
+			$g_loc->{time_zone} = ($rec->time_zone) ? $rec->time_zone : "GEO_NULL";
+			$g_loc->{area_code} = ($rec->{area_code}) ? $rec->{area_code} : "GEO_NULL";
+			$g_loc->{metro_code} = ($rec->{metro_code}) ? $rec->{metro_code} : "GEO_NULL";
 		}
 		my ($from, $to) = $gi->range_by_ip($ip);
 		my $range = "$from-$to";
@@ -2235,8 +2277,7 @@ sub learn
 				$choice = <STDIN>;
 				chomp;
 			}while($choice !~ m/^(y(es)?|n[o]?)\b/i);			
-			if($choice =~ m/^[Yy](es)?$/)
-			{
+			if($choice =~ m/^[Yy](es)?$/){
 				print "\nNote:\n";
 				print "- The entered filter will be treated as a regular expression.\n";
 				print "- Ensure you escape if in doubt (e.g., octet separators)\n";
@@ -2275,6 +2316,9 @@ sub learn
 						push(@filters, $skip_filter);
 					}
 				}
+			}else{
+				$skip_to_main = 1;
+				redo;
 			}
 			if(($#filters + 1) > 0){
 				$do_skip_filter = 1;
@@ -3307,7 +3351,7 @@ sub monitor_server
 		}
 		$date = localtime();
 		chomp($packet);
-		($packet, $client_msg) = split(/\|/, $packet, 2);
+		($traf_hdr, $packet, $client_msg) = split(/\|/, $packet, 3);
 		$seen = build_cache($packet, \%packet_data, $date, $record_id, 
 			$arg->{do_cache_key_dst}, \$src, \$dst);
 		if(! $seen){
@@ -3316,9 +3360,9 @@ sub monitor_server
 				$log_msg = "Client Message|$date|$arg->{name}|$pid|$arg->{host}:$arg->{port}|";
 				if($arg->{do_cache_key_dst}){
 					my $peer = $socket->peerhost.":".$socket->peerport;
-					$log_msg .= "$peer|$protocol|$src > $dst";
+					$log_msg .= "PEER|$peer|PROTOCOL|$protocol|$traf_hdr|$src > $dst";
 				}else{
-					$log_msg .= "$peer|$protocol|$packet";
+					$log_msg .= "PEER|$peer|PROTOCOL|$protocol|$traf_hdr|$packet";
 				}
 				$log_msg .= "|$client_msg\n";
 				log_message($log_msg, $arg->{log_server});
@@ -3338,7 +3382,7 @@ sub monitor_server
 						$log_msg .= "Reached packet cache limit of $packet_count\n";
 						log_message($log_msg, $arg->{log_server});
 					}
-					print STDERR "\n\n-- Reached packet cache limit of $packet_count (server pid: $pid).\n" 
+					print STDERR "\n-- Reached packet cache limit of $packet_count (server pid: $pid).\n" 
 						unless($arg->{do_daemon});
 					$total_keys = keys(%packet_data);
 					if($arg->{do_log}){
@@ -3461,7 +3505,7 @@ sub monitor_server
 						$log_msg .= "Refreshing of server done\n";
 						log_message($log_msg, $arg->{log_server});
 					}
-					print STDERR "done.\n" unless($arg->{do_daemon});
+					print STDERR "done.\n\n" unless($arg->{do_daemon});
 				}
 			}
 		}
@@ -3730,7 +3774,7 @@ sub monitor_client
 				log_message($log_msg, $arg->{log_client});
 				$log_msg = "Message|$date|$arg->{name}|$pid|$arg->{host}:$arg->{port}|";
 				$log_msg .= "Total packets (Network, IP, Requested, Captured, Unique): ";
-				$log_msg .= "$total_net_packets,  $total_ip_packets, $packet_max, ";
+				$log_msg .= "$total_net_packets, $total_ip_packets, $packet_max, ";
 				$log_msg .= "$packet_count, $ucount\n";
 				log_message($log_msg, $arg->{log_client});
 			}
@@ -3742,48 +3786,80 @@ sub monitor_client
 			}
 			last;
 		}else{
-			$client_msg = "$packet|$record_id";
+			$client_msg = "TRAFFIC|$packet|RECORD|$record_id";
 			if($arg->{do_packet_detail}){
-				 $client_msg .= "|$hdr|$tcp_flag";
+				 $client_msg .= "|HEADER|$hdr|FLAG|$tcp_flag";
 			}
 			if($arg->{do_geo_src}){
-				 if($arg->{geo_src_info_flag} == 1){
-					 $client_msg .= "|$g_loc_src{continent_code}|$g_loc_src{country_code3}";
-					 $client_msg .= "|$g_loc_src{country_name}|$g_loc_src{city}";
-					 $client_msg .= "|$g_loc_src{region_name}|$g_loc_src{postal_code}";
-					 $client_msg .= "|$g_loc_src{latitude}|$g_loc_src{longitude}";
-					 $client_msg .= "|$g_loc_src{time_zone}|$g_loc_src{area_code}";
-					 $client_msg .= "|$g_loc_src{metro_code}";
-				 }elsif($arg->{geo_src_info_flag} == 2){
-					 $client_msg .= "|$g_ip4_src[0]|$g_ip4_src[1]|$g_ip4_src[2]|$g_ip4_src[3]";
+				if($arg->{geo_src_info_flag} == 1){
+				 	$client_msg .= "|SRC_CONTINENT_CODE|$g_loc_src{continent_code}";
+				 	$client_msg .= "|SRC_COUNTRY_CODE3|$g_loc_src{country_code3}";
+				 	$client_msg .= "|SRC_COUNTRY_NAME|$g_loc_src{country_name}";
+				 	$client_msg .= "|SRC_CITY|$g_loc_src{city}";
+				 	$client_msg .= "|SRC_REGION_NAME|$g_loc_src{region_name}";
+				 	$client_msg .= "|SRC_POSTAL_CODE|$g_loc_src{postal_code}";
+				 	$client_msg .= "|SRC_LATITUDE|$g_loc_src{latitude}";
+				 	$client_msg .= "|SRC_LONGITUDE|$g_loc_src{longitude}";
+				 	$client_msg .= "|SRC_TIME_ZONE|$g_loc_src{time_zone}";
+				 	$client_msg .= "|SRC_AREA_CODE|$g_loc_src{area_code}";
+				 	$client_msg .= "|SRC_METRO_CODE|$g_loc_src{metro_code}";
+				}elsif($arg->{geo_src_info_flag} == 2){
+				 	$client_msg .= "|SRC_IP4_MIN|$g_ip4_src[0]";
+				 	$client_msg .= "|SRC_IP4_MAX|$g_ip4_src[1]";
+				 	$client_msg .= "|SRC_IP4_MASK|$g_ip4_src[2]";
+				 	$client_msg .= "|SRC_IP4_CIDR|$g_ip4_src[3]";
 				 }else{
-					 $client_msg .= "|$g_loc_src{continent_code}|$g_loc_src{country_code3}";
-					 $client_msg .= "|$g_loc_src{country_name}|$g_loc_src{city}";
-					 $client_msg .= "|$g_loc_src{region_name}|$g_loc_src{postal_code}";
-					 $client_msg .= "|$g_loc_src{latitude}|$g_loc_src{longitude}";
-					 $client_msg .= "|$g_loc_src{time_zone}|$g_loc_src{area_code}";
-					 $client_msg .= "|$g_loc_src{metro_code}";
-					 $client_msg .= "|$g_ip4_src[0]|$g_ip4_src[1]|$g_ip4_src[2]|$g_ip4_src[3]";
+				 	$client_msg .= "|SRC_CONTINENT_CODE|$g_loc_src{continent_code}";
+				 	$client_msg .= "|SRC_COUNTRY_CODE3|$g_loc_src{country_code3}";
+				 	$client_msg .= "|SRC_COUNTRY_NAME|$g_loc_src{country_name}";
+				 	$client_msg .= "|SRC_CITY|$g_loc_src{city}";
+				 	$client_msg .= "|SRC_REGION_NAME|$g_loc_src{region_name}";
+				 	$client_msg .= "|SRC_POSTAL_CODE|$g_loc_src{postal_code}";
+				 	$client_msg .= "|SRC_LATITUDE|$g_loc_src{latitude}";
+				 	$client_msg .= "|SRC_LONGITUDE|$g_loc_src{longitude}";
+				 	$client_msg .= "|SRC_TIME_ZONE|$g_loc_src{time_zone}";
+				 	$client_msg .= "|SRC_AREA_CODE|$g_loc_src{area_code}";
+				 	$client_msg .= "|SRC_METRO_CODE|$g_loc_src{metro_code}";
+				 	$client_msg .= "|SRC_IP4_MIN|$g_ip4_src[0]";
+				 	$client_msg .= "|SRC_IP4_MAX|$g_ip4_src[1]";
+				 	$client_msg .= "|SRC_IP4_MASK|$g_ip4_src[2]";
+				 	$client_msg .= "|SRC_IP4_CIDR|$g_ip4_src[3]";
 				 }
 			}
 			if($arg->{do_geo_dst}){
 				 if($arg->{geo_dst_info_flag} == 1){
-					 $client_msg .= "|$g_loc_dst{continent_code}|$g_loc_dst{country_code3}";
-					 $client_msg .= "|$g_loc_dst{country_name}|$g_loc_dst{city}";
-					 $client_msg .= "|$g_loc_dst{region_name}|$g_loc_dst{postal_code}";
-					 $client_msg .= "|$g_loc_dst{latitude}|$g_loc_dst{longitude}";
-					 $client_msg .= "|$g_loc_dst{time_zone}|$g_loc_dst{area_code}";
-					 $client_msg .= "|$g_loc_dst{metro_code}";
-				 }elsif($arg->{geo_dst_info_flag} == 2){
-					 $client_msg .= "|$g_ip4_dst[0]|$g_ip4_dst[1]|$g_ip4_dst[2]|$g_ip4_dst[3]";
+				 	$client_msg .= "|DST_CONTINENT_CODE|$g_loc_dst{continent_code}";
+				 	$client_msg .= "|DST_COUNTRY_CODE3|$g_loc_dst{country_code3}";
+				 	$client_msg .= "|DST_COUNTRY_NAME|$g_loc_dst{country_name}";
+				 	$client_msg .= "|DST_CITY|$g_loc_dst{city}";
+				 	$client_msg .= "|DST_REGION_NAME|$g_loc_dst{region_name}";
+				 	$client_msg .= "|DST_POSTAL_CODE|$g_loc_dst{postal_code}";
+				 	$client_msg .= "|DST_LATITUDE|$g_loc_dst{latitude}";
+				 	$client_msg .= "|DST_LONGITUDE|$g_loc_dst{longitude}";
+				 	$client_msg .= "|DST_TIME_ZONE|$g_loc_dst{time_zone}";
+				 	$client_msg .= "|DST_AREA_CODE|$g_loc_dst{area_code}";
+				 	$client_msg .= "|DST_METRO_CODE|$g_loc_dst{metro_code}";
+				}elsif($arg->{geo_dst_info_flag} == 2){
+				 	$client_msg .= "|DST_IP4_MIN|$g_ip4_dst[0]";
+				 	$client_msg .= "|DST_IP4_MAX|$g_ip4_dst[1]";
+				 	$client_msg .= "|DST_IP4_MASK|$g_ip4_dst[2]";
+				 	$client_msg .= "|DST_IP4_CIDR|$g_ip4_dst[3]";
 				 }else{
-					 $client_msg .= "|$g_loc_dst{continent_code}|$g_loc_dst{country_code3}";
-					 $client_msg .= "|$g_loc_dst{country_name}|$g_loc_dst{city}";
-					 $client_msg .= "|$g_loc_dst{region_name}|$g_loc_dst{postal_code}";
-					 $client_msg .= "|$g_loc_dst{latitude}|$g_loc_dst{longitude}";
-					 $client_msg .= "|$g_loc_dst{time_zone}|$g_loc_dst{area_code}";
-					 $client_msg .= "|$g_loc_dst{metro_code}";
-					 $client_msg .= "|$g_ip4_dst[0]|$g_ip4_dst[1]|$g_ip4_dst[2]|$g_ip4_dst[3]";
+				 	$client_msg .= "|DST_CONTINENT_CODE|$g_loc_dst{continent_code}";
+				 	$client_msg .= "|DST_COUNTRY_CODE3|$g_loc_dst{country_code3}";
+				 	$client_msg .= "|DST_COUNTRY_NAME|$g_loc_dst{country_name}";
+				 	$client_msg .= "|DST_CITY|$g_loc_dst{city}";
+				 	$client_msg .= "|DST_REGION_NAME|$g_loc_dst{region_name}";
+				 	$client_msg .= "|DST_POSTAL_CODE|$g_loc_dst{postal_code}";
+				 	$client_msg .= "|DST_LATITUDE|$g_loc_dst{latitude}";
+				 	$client_msg .= "|DST_LONGITUDE|$g_loc_dst{longitude}";
+				 	$client_msg .= "|DST_TIME_ZONE|$g_loc_dst{time_zone}";
+				 	$client_msg .= "|DST_AREA_CODE|$g_loc_dst{area_code}";
+				 	$client_msg .= "|DST_METRO_CODE|$g_loc_dst{metro_code}";
+				 	$client_msg .= "|DST_IP4_MIN|$g_ip4_dst[0]";
+				 	$client_msg .= "|DST_IP4_MAX|$g_ip4_dst[1]";
+				 	$client_msg .= "|DST_IP4_MASK|$g_ip4_dst[2]";
+				 	$client_msg .= "|DST_IP4_CIDR|$g_ip4_dst[3]";
 				 }
 			}
 			if($arg->{do_unique}){
@@ -3799,9 +3875,9 @@ sub monitor_client
 						$log_msg .= "$client_msg\n";
 						log_message($log_msg, $arg->{log_client});
 					}
-				}
-				$socket->send($client_msg) 
+					$socket->send($client_msg) 
 					or die("$!: $arg->{name} (pid: $pid) unable to send to $arg->{host}:$arg->{port}\n");
+				}
 				$data{$packet}++;
 			}else{
 				if($arg->{do_stdout}){
@@ -3815,7 +3891,7 @@ sub monitor_client
 					$log_msg .= "$client_msg\n";
 					log_message($log_msg, $arg->{log_client});
 				}
-				$socket->send($client_msg) 
+				$socket->send("$client_msg") 
 					or die("$!: $arg->{name} (pid: $pid) unable to send to $arg->{host}:$arg->{port}\n");
 				$data{$packet_count} = $packet;
 			}
@@ -4420,7 +4496,11 @@ sub usage
     print STDERR "\t# is preferred, you can pass this instead (see: --interface)\n";
     print STDERR "\t# If you are not sure what devices are available, you can\n";
     print STDERR "\t# leverage various commands to provide a list. Alternatively,\n";
-    print STDERR "\t# $arg->{name} can attempt to do so (see: --list-interfaces).\n\n";
+    print STDERR "\t# $arg->{name} can attempt to do so (see: --list-interfaces).\n";
+    print STDERR "\t# You can stop capturing at any time by sending an interrupt\n";
+    print STDERR "\t# such as pressing: 'control + c', sending a INT signal, or by\n";
+    print STDERR "\t# sending an TERM signal. You can see current capture stats by\n";
+    print STDERR "\t# sending a USR1 signal.\n\n";
     print STDERR "-gc, --get-cidr <ip-range>\n"; 
     print STDERR "\t# Return CIDR blocks, given <ip-range>. This can be useful to\n";
     print STDERR "\t# ensure all CIDR blocks are covered for various rules. For\n";
@@ -4466,7 +4546,10 @@ sub usage
 	print STDERR "\t# reached (see: --packet-count). This command is most useful once\n";
 	print STDERR "\t# you believe you have captured sufficient traffic for the given\n";
 	print STDERR "\t# environment (see: --capture) and/or have sufficiently created\n";
-	print STDERR "\t# rules to minimize false positives/negatives (see: --learn).\n\n";
+	print STDERR "\t# rules to minimize false positives/negatives (see: --learn).\n";
+	print STDERR "\t# You can stop monitoring at any time by sending an interrupt\n";
+    print STDERR "\t# such as pressing: 'control + c', sending a INT signal, or by\n";
+    print STDERR "\t# sending an TERM signal.\n\n";
 	print STDERR "--sort-learn=<auth | unauth> [lfile]\n";
 	print STDERR "\t# Sorts learned data by authorized or unauthorized. Should [lfile]\n";
 	print STDERR "\t# be omitted, then $arg->{lfile} is used. This command is useful\n";

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -152,10 +152,10 @@ is capturing packets by passing a "SIGUSR1" signal to the process. If this is
 done, netcap will dump stats similar to the following:
 
 ...
-192.168.0.40:5353 > 224.0.0.251:5353
-192.168.0.11:1053 > 239.255.255.250:8082
-192.168.0.40:45164 > 239.255.255.250:1900
-192.168.0.36:65484 > 172.20.25.18:443
+TRAFFIC|192.168.0.40:5353 > 224.0.0.251:5353
+TRAFFIC|192.168.0.11:1053 > 239.255.255.250:8082
+TRAFFIC|192.168.0.40:45164 > 239.255.255.250:1900
+TRAFFIC|192.168.0.36:65484 > 172.20.25.18:443
 
 
 -- User signal caught (pid: 45036).
@@ -167,10 +167,10 @@ Unique: 155
 
 netcap (pid: 45036) continuing with capturing traffic.
 
-192.168.0.40:49198 > 239.255.255.250:1900
-192.168.0.36:65485 > 172.20.25.18:443
-192.168.0.36:65486 > 143.192.7.24:443
-192.168.0.36:62190 > 192.168.0.1:53
+TRAFFIC|192.168.0.40:49198 > 239.255.255.250:1900
+TRAFFIC|192.168.0.36:65485 > 172.20.25.18:443
+TRAFFIC|192.168.0.36:65486 > 143.192.7.24:443
+TRAFFIC|192.168.0.36:62190 > 192.168.0.1:53
 ...
 
 If there are more packets to capture from --packet-count or you omitted 
@@ -189,12 +189,12 @@ o The bit sequence set in the packet transport protocol (if any)
 
 Example:
 ...
-192.168.0.45:64099 > 172.20.25.18:443|62:62:1478572176:577471|tcp:SYN:2
-192.168.0.2:1048 > 239.255.255.250:8082|64:1514:1478572176:873878|udp:none:195
-192.168.0.2:8291 > 239.255.255.250:29757|64:1162:1478572176:885485|tcp:none:48
-192.168.0.11:1053 > 239.255.255.250:8082|64:505:1478572178:479122|udp:none:195
-132.245.51.2:443 > 192.168.0.45:64094|64:1184:1478572180:733472|tcp:PSH/ACK:24
-192.168.0.45:64094 > 132.245.51.2:443|64:66:1478572180:733607|tcp:ACK:16
+TRAFFIC|192.168.0.45:64099 > 172.20.25.18:443|HEADER|62:62:1478572176:577471|FLAG|tcp:SYN:2
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082|HEADER|64:1514:1478572176:873878|FLAG|udp:none:195
+TRAFFIC|192.168.0.2:8291 > 239.255.255.250:29757|HEADER|64:1162:1478572176:885485|FLAG|tcp:none:48
+TRAFFIC|192.168.0.11:1053 > 239.255.255.250:8082|HEADER|64:505:1478572178:479122|FLAG|udp:none:195
+TRAFFIC|132.245.51.2:443 > 192.168.0.45:64094|HEADER|64:1184:1478572180:733472|FLAG|tcp:PSH/ACK:24
+TRAFFIC|192.168.0.45:64094 > 132.245.51.2:443|HEADER|64:66:1478572180:733607|FLAG|tcp:ACK:16
 
 When capturing packets, the amount of traffic (especially on a busy network) 
 could be overwhelming. There are several options you can use to aid with 
@@ -207,16 +207,16 @@ are returned.
 
 Example WITHOUT using the unique functionality:
 ...
-192.168.0.11:1053 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.11:1053 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
 
 Total packets:
 Network: 48	IP: 11
@@ -226,8 +226,8 @@ Unique: Not enabled
 
 Example WITH using the unique functionality:
 ...
-192.168.0.11:1053 > 239.255.255.250:8082
-192.168.0.2:1048 > 239.255.255.250:8082
+TRAFFIC|192.168.0.11:1053 > 239.255.255.250:8082
+TRAFFIC|192.168.0.2:1048 > 239.255.255.250:8082
 
 Total packets:
 Network: 19	IP: 11
@@ -248,8 +248,8 @@ approach this. See pcresyntax(3) for more detail.
 
 Example:
 ...
-192.168.0.11:23674 >  69.89.31.56:21
-192.168.0.10:21364 >  176.74.176.187:23
+TRAFFIC|192.168.0.11:23674 >  69.89.31.56:21
+TRAFFIC|192.168.0.10:21364 >  176.74.176.187:23
 ...
 
 The regular expression filter is good, but there may be some need to leverage 
@@ -260,16 +260,165 @@ using the regular expression filter (--regex). This would be fine, but what if
 the IP changed or the list of CNAMEs were numerous? Rather than be concerned 
 with that nonsense, we can simply leverage a simple filter and having this 
 figured out. In this case, we rely on: --compile-filter and set it to the 
-host we care about: "host (www.foo.com or www.bar.com)". See pcap-filter(7) 
-for more detail on filtering syntax.
+host we care about: "host (www.foo.com or www.bar.com)".
 
 Example:
 ...
-192.168.20.42:23674 > 204.236.134.199:80
-204.236.134.199:80 > 192.168.20.42:23674
-192.168.10.100:33621 > 104.27.138.186:443
-104.27.138.186:443 > 192.168.10.100:33621
+TRAFFIC|192.168.20.42:23674 > 204.236.134.199:80
+TRAFFIC|204.236.134.199:80 > 192.168.20.42:23674
+TRAFFIC|192.168.10.100:33621 > 104.27.138.186:443
+TRAFFIC|104.27.138.186:443 > 192.168.10.100:33621
 ...
+
+The packet filtering rules of libpcap also supports more general packet 
+expressions, where arbitrary byte ranges in a packet are checked with relation 
+or binary operators. For byte range representation, you can use the following 
+format:
+
+proto [expr : size]
+
+- "proto" can be one of well-known protocols (e.g., ip, tcp, udp)
+- "expr" represents byte offset relative to the beginning of a specified 
+protocol header. For example: tcp[0] means always means the first byte of the 
+TCP header. You can specify the number of bytes past the TCP header and where 
+the flags reside. You can then specify which flag(s) by doing something like:
+
+--compile-filter "(tcp[13] == 2)"
+
+The above would return packets with the SYN bit set.
+
+--compile-filter "(tcp[13] == 20)"
+
+The above would return packets with the SYN and ACK bit set.
+
+--compile-filter "(tcp[13] == 24)"
+
+The above would return packets with PUSH and ACK bit set.
+
+The flags correspond to the following decimal structure:
+
+1 	= FIN
+2 	= SYN
+4 	= RST
+8 	= PSH
+16 	= ACK
+17	= FIN/ACK
+18	= SYN/ACK
+20	= RST/ACK
+24	= PSH/ACK
+32 	= URG
+
+Well known byte offsets exist such as "tcpflags" or value constants such as: 
+
+tcp-urg
+tcp-syn
+tcp-ack
+tcp-push
+tcp-rst
+tcp-fin 
+
+- "size" is optional, indicating the number of bytes to check starting from the 
+byte offset.
+
+Examples:
+
+TCP SYN:
+
+--compile-filter "(tcp[13] & 2 != 0)"
+
+Example:
+...
+TRAFFIC|192.168.0.45:55246 > 104.25.10.6:443|HEADER|64:78:1480100880:874146|FLAG|tcp:SYN:2
+TRAFFIC|104.25.10.6:443 > 192.168.0.45:55246|HEADER|64:66:1480100880:921384|FLAG|tcp:SYN/ACK:18
+
+TCP SYN:
+
+--compile-filter "tcp[tcpflags] & (tcp-syn) != 0"
+
+This can be exploited by passing any valid option to netcap's --compile-filter.
+
+Example:
+...
+TRAFFIC|192.168.0.45:54645 > 52.32.74.117:443|HEADER|64:78:1480099998:72602|FLAG|tcp:SYN:2
+TRAFFIC|52.32.74.117:443 > 192.168.0.45:54645|HEADER|64:74:1480099998:140910|FLAG|tcp:SYN/ACK:18
+
+TCP ACK:
+
+--compile-filter "(tcp[13] & 16 != 0)"
+
+Example:
+...
+TRAFFIC|132.245.70.82:443 > 192.168.0.45:54228|HEADER|64:128:1480101089:936922|FLAG|tcp:PSH/ACK:24
+
+TCP SYN or ACK:
+
+"tcp[tcpflags] & (tcp-syn|tcp-ack) != 0"
+
+Example:
+...
+TRAFFIC|192.168.0.45:54290 > 209.197.3.19:443|HEADER|64:78:1480099739:697276|FLAG|tcp:SYN:2
+TRAFFIC|209.197.3.19:443 > 192.168.0.45:54290|HEADER|64:74:1480099739:745061|FLAG|tcp:SYN/ACK:18
+TRAFFIC|52.26.195.87:80 > 192.168.0.45:54291|HEADER|64:66:1480099739:969075|FLAG|tcp:ACK:16
+TRAFFIC|192.168.0.45:54291 > 52.26.195.87:80|HEADER|64:480:1480099740:13057|FLAG|tcp:PSH/ACK:24
+TRAFFIC|192.168.0.45:52207 > 184.51.1.19:443|HEADER|64:66:1480099740:269766|FLAG|tcp:FIN/ACK:17
+
+TCP FIN:
+
+--compile-filter "tcp[tcpflags] & (tcp-fin) != 0"
+
+Example:
+...
+TRAFFIC|54.244.227.86:80 > 192.168.0.45:53683|HEADER|64:66:1480099478:780431|FLAG|tcp:FIN/ACK:17
+
+
+TCP RST:
+
+--compile-filter "(tcp[13] & 4 != 0)"
+
+Example:
+...
+TRAFFIC|192.168.0.45:55290 > 50.16.206.36:80|HEADER|54:54:1480100983:839989|FLAG|tcp:RST:4
+
+TCP RST:
+
+--compile-filter "tcp[tcpflags] & (tcp-rst) != 0"
+
+Example:
+...
+TRAFFIC|192.168.0.45:54488 > 54.149.124.73:443|HEADER|54:54:1480099910:545684|FLAG|tcp:RST:4
+
+HTTP GET:
+
+--compile-filter "(tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x47455420)"
+--compile-filter "(tcp[32:4] = 0x47455420)"
+
+Example:
+...
+TRAFFIC|192.168.0.45:50374 > 72.21.91.8:80|HEADER|64:814:1480349016:591647|FLAG|tcp:PSH/ACK:24
+
+HTTP POST:
+
+--compile-filter "(tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x504f5354)"
+--compile-filter "(tcp[32:4] = 0x504f5354)"
+
+Example:
+...
+TRAFFIC|172.21.9.253:53700 > 72.21.91.8:80|HEADER|64:934:1480355561:647320|FLAG|tcp:PSH/ACK:24
+
+HTTP REQUEST/RESPONSE HEADERS:
+
+--compile-filter "(((ip[2:2] - ((ip[0] & 0xf)<<2)) - ((tcp[12] & 0xf0)>>2)) != 0)"
+
+Example:
+...
+TRAFFIC|172.21.9.253:53714 > 92.222.168.187:443|HEADER|64:249:1480355683:708116|FLAG|tcp:PSH/ACK:24
+...
+TRAFFIC|192.168.0.45:54020 > 173.255.199.118:443|HEADER|64:260:1480355739:88131|FLAG|tcp:PSH/ACK:24
+
+NOTE: 
+- See pcap-filter(7) for more detail on filtering syntax
+- See: https://www.wireshark.org/tools/string-cf.html for a tool that can lets 
+you create capture filters that match strings in TCP payloads
 
 Another option that could be useful when capturing is to lookup up geographical 
 information based on location and IPv4 information. This can be useful for 
@@ -319,9 +468,11 @@ is used AND the IP address used for the lookup falls within the following:
 	"Loopback" IP addresses:
 		127.0.0.0 - 127.255.255.255
 
-If an IP falls within any of the above, the lookup value returned is prefixed 
-with: PU, MC, BC, AC, LB respectively. Otherwise, a lookup is attempted 
-and if a value is not found, NULL is returned for the respective value. 
+If an IP falls within any of the above, a NULL is assigned for a lookup. Based 
+on where the IP address falls within the address ranges above, the NULL is 
+prefixed with: PU, MC, BC, AC, LB respectively. Otherwise, a lookup is 
+attempted from the GEO database. If a value is not found in the database, 
+GEO_NULL is returned for the respective value. 
 
 The prefix identifiers map as follows:
 	RFC1918 / "Private Use" = PU
@@ -353,15 +504,15 @@ The fields for a IPv4 lookup (GEO_IP4_INFO) are:
 As an example, we will capture 10 packets, fetch both source and destination 
 information for location and IPv4. We named our GEO DB "geolite.dat" and 
 point netcap to its location. We will only be concerned with port 80 or 443 
-traffic (HTTP, HTTPS) where the traffic is for www.iana.org and the packets 
-are from www.iana.org (i.e. return traffic). We will specify that we are only  
+traffic (HTTP, HTTPS) where the traffic is for www.foobar.com and the packets 
+are from www.foobar.com (i.e. return traffic). We will specify that we are only  
 interested in unique packets. Finally, we will write the results to both stdout 
 and to a capture file residing in our home: ~/Desktop/cap.txt:
 
-$ ./netcap -c -s -cf ~/Desktop/cap.txt -gd fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=~/Desktop/geolite.dat -gs fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=~/Desktop/geolite.dat -pc 10 -re "^.*:(80\b|443)\s+>" -u --compile-filter "host www.iana.org"
+$ bin/netcap -c -s -cf ~/Desktop/cap.txt -gd fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=~/Desktop/geolite.dat -gs fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=~/Desktop/geolite.dat -pc 10 -re "^.*:(80\b|443)\s+>" -u --compile-filter "host www.foobar.com"
 
 ...
-192.0.32.8:443 > 192.168.0.45:63192|NA|USA|United States|Los Angeles|California|90066|34.0039|-118.4338|America/Los_Angeles|310|803|192.0.32.0|192.0.47.255|255.255.240.0|192.0.32.0/20|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|RFC1918_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16
+TRAFFIC|69.89.31.56:80 > 192.168.0.45:63688|SRC_CONTINENT_CODE|NA|SRC_COUNTRY_CODE3|USA|SRC_COUNTRY_NAME|United States|SRC_CITY|Provo|SRC_REGION_NAME|Utah|SRC_POSTAL_CODE|84606|SRC_LATITUDE|40.2181|SRC_LONGITUDE|-111.6133|SRC_TIME_ZONE|America/Denver|SRC_AREA_CODE|801|SRC_METRO_CODE|770|SRC_IP4_MIN|69.89.16.0|SRC_IP4_MAX|69.89.31.255|SRC_IP4_MASK|255.255.240.0|SRC_IP4_CIDR|69.89.16.0/20|DST_CONTINENT_CODE|PU_NULL|DST_COUNTRY_CODE3|PU_NULL|DST_COUNTRY_NAME|PU_NULL|DST_CITY|PU_NULL|DST_REGION_NAME|PU_NULL|DST_POSTAL_CODE|PU_NULL|DST_LATITUDE|PU_NULL|DST_LONGITUDE|PU_NULL|DST_TIME_ZONE|PU_NULL|DST_AREA_CODE|PU_NULL|DST_METRO_CODE|PU_NULL|DST_IP4_MIN|192.168.0.0|DST_IP4_MAX|192.168.255.255|DST_IP4_MASK|255.255.0.0|DST_IP4_CIDR|192.168.0.0/16
 
 Total packets:
 Network: 203	IP: 14
@@ -369,7 +520,7 @@ Requested: 10	Captured: 10
 Unique: 1
 ...
 
-In the above example, we can see the destination (192.0.32.8) information is 
+In the above example, we can see the destination (69.89.31.56) information is 
 retrieved for both location and IPv4. The source (192.168.0.45) falls within 
 the RFC1918 address space and is prefixed with "PU" (Private Use) identifier. 
 
@@ -589,12 +740,12 @@ just set the rule to unauthorized and you should quickly see if anything is
 awry. For example:
 
 # watch for FTP, TELNET, and TFTP
-!;0.0.0.0/0:* > 0.0.0.0/0:(2[013]|69)\b;...;1
-;0.0.0.0/0:* > 0.0.0.0/0:*;...;0
+!;0.0.0.0/0:* > 0.0.0.0/0:(2[013]|69)\b;...[rest of rule omitted]...;1
+;0.0.0.0/0:* > 0.0.0.0/0:*;...[rest of rule omitted]...;0
 
 # catch anything NOT already learned
 ... [other rules here] ...
-!;0.0.0.0/0:* > 0.0.0.0/0:*;...;0
+!;0.0.0.0/0:* > 0.0.0.0/0:*;...[rest of rule omitted]...;0
 
 Note:
 - netcap will ignore captured traffic that matches a learned rule. The 
@@ -637,7 +788,7 @@ examples:
 		- match all ports:
 		\d{1,5}, *
 		
-- See ./netcap --help for more information on learn mode options.
+- See netcap --help for more information on learn mode options.
 
 C. Monitor Mode
 
@@ -744,77 +895,108 @@ If more granularity is needed, you can leverage powerful features such as the
 --regex and --compile-filter options. These can be leveraged separately or 
 together as needed.
 
-As mentioned in the ClIENT section of this document, another option that could 
+As mentioned in the CAPTURE section of this document, another option that could 
 prove useful is netcap's ability to conduct geographical and IPv4 lookups. This 
-can be beneficial for analysis and analytics. See the CLIENT section to see 
+can be beneficial for analysis and analytics. See the CAPTURE section to see 
 more information. In this section, we assume to are aware of why you would want 
 to use it and just want to illustrate a simple example scenario:
 
 Scenario:
 =========
 
-You decide that traffic to www.blackhat.com is unauthorized - you worry that no 
+You decide that traffic to www.foobar.com is unauthorized - you worry that no 
 good can possibly come from visiting this site - in all seriousness, the point 
-is that www.blackhat.com can be replaced with any website that is ACTUALLY a 
-site that could cause harm; just using this site as an example only :)
+is that www.foobar.com can be replaced with any website that is ACTUALLY a 
+site that could cause harm.
 
 We are in a monitoring situation and have a client and server. In this example, 
-we are interested in monitoring traffic to www.blackhat.com where data is being 
+we are interested in monitoring traffic to www.foobar.com where data is being 
 passed (not concerned with other traffic). We will conduct a source and server 
-GEO DB lookup for both location and IPv4. There are other options being used, 
-but the only other real important one is to note that we only want unique 
-traffic returned. On the server side, we have typical options specified. One 
-interesting option is -pc (--packet-count) is set to 1. In this example, we 
-want to know when see even 1 event. Since we have also asked our server to 
-notify us, we would immediately learn of this happening, should we not be 
-watching the logs (or the console as we were not running in daemon mode).
+GEO DB lookup for both location and IPv4 as well. There are other options being used on the client, but the only other real important one is to note that we 
+only want unique traffic returned. 
+
+On the server side, one interesting option to note is -pc (--packet-count) is 
+set to 1. This is because we want to know when see even one event for this 
+scenario. Since we have also asked our server to notify us, we would learn of 
+this happening immediately. 
 
 Client:
 =======
 
-$ ./netcap -m --client localhost 55555 --log=client ~/Desktop/client.log -s -p -pd --compile-filter "host www.blackhat.com && (tcp[tcpflags] & (tcp-push) != 0)" -gd fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=etc/geolite.dat -gs fetch="GEO_LOC_INFO|GEO_IP4_INFO" db=etc/geolite.dat -u 
+$ bin/netcap -m --client localhost 55555 --log=client var/client.log -s -p -pd --compile-filter "host www.foobar.com && (tcp[tcpflags] & (tcp-push) != 0)" -gd fetch="GEO_IP4_INFO|GEO_LOC_INFO" db=etc/geolite.dat -gs fetch="GEO_LOC_INFO|GEO_IP4_INFO" db=etc/geolite.dat -u
 
 Server:
 =======
 
-$ ./netcap -m --server localhost 55555 --cache-file ~/Desktop/cache.txt --cache-key-dst --log=server ~/Desktop/server.log -n out=~/Desktop/notify.txt --sort-cache-date -pc 1 -s
+$ bin/netcap -m --server localhost 55555 --cache-file var/cache.txt --cache-key-dst --log=server var/server.log -n out=var/notify.txt --sort-cache-date -pc 1 -s
 
 Now that we have our monitoring up, we sit back and relax. At some point, we 
-see events. This happens after traffic to www.blackhat.com is seen. Below are 
+see events. This happens after traffic to www.foobar.com is seen. Below are 
 the example results. Take note of the amount traffic observed on the client 
-compared to that of the client (thanks to the unique flag):
+compared to that of the server (thanks to the unique flag):
 
 Client:
 =======
 
-Client Running|Sun Nov 20 16:32:36 2016|netcap|42658|localhost:55555|udp
+Client Running|Wed Nov 23 18:43:53 2016|netcap|10778|localhost:55555|udp
 Binding to interface: en0... Listening (promiscuous mode = Yes)...
-Server Message|Sun Nov 20 16:32:39 2016|netcap|42658|localhost:55555|udp|192.168.0.45:63980 > 104.20.65.243:80|0|64:652:1479684759:35314|tcp:PSH/ACK:24|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12
-Server Message|Sun Nov 20 16:32:39 2016|netcap|42658|localhost:55555|udp|192.168.0.45:63961 > 104.20.65.243:443|0|64:875:1479684759:234384|tcp:PSH/ACK:24|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12
-Server Message|Sun Nov 20 16:32:39 2016|netcap|42658|localhost:55555|udp|192.168.0.45:63985 > 104.20.65.243:80|0|64:732:1479684759:580722|tcp:PSH/ACK:24|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12
-Server Message|Sun Nov 20 16:32:39 2016|netcap|42658|localhost:55555|udp|104.20.65.243:443 > 192.168.0.45:63961|0|64:571:1479684759:609745|tcp:PSH/ACK:24|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16
+Server Message|Wed Nov 23 18:43:59 2016|netcap|10778|localhost:55555|udp|TRAFFIC|192.168.0.45:64086 > 104.20.66.243:80|RECORD|0|HEADER|64:627:1479951839:174999|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
+Server Message|Wed Nov 23 18:43:59 2016|netcap|10778|localhost:55555|udp|TRAFFIC|192.168.0.45:64066 > 104.20.65.243:443|RECORD|0|HEADER|64:891:1479951839:362970|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
+Server Message|Wed Nov 23 18:43:59 2016|netcap|10778|localhost:55555|udp|TRAFFIC|192.168.0.45:64091 > 104.20.66.243:80|RECORD|0|HEADER|64:739:1479951839:715671|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
+Server Message|Wed Nov 23 18:43:59 2016|netcap|10778|localhost:55555|udp|TRAFFIC|192.168.0.45:64094 > 104.20.65.243:80|RECORD|0|HEADER|64:743:1479951839:808667|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
 ... [OTHER UNIQUE TRAFFIC OMITTED] ...
-
 ... [AT SOME POINT AN INTERRUPT IS SENT] ...
-
+^C
 -- Interrupt signal caught. Wrapping up...
 
 Total packets:
-Network: 3373	IP: 3194
-Requested: Indefinite amount	Captured: 3194
-Unique: 15
+Network: 11595	IP: 11119
+Requested: Indefinite amount	Captured: 10297
+Unique: 8
 ...
 
 Server:
 =======
 
-Server Running|Sun Nov 20 16:32:33 2016|netcap|42657|localhost:55555|udp
-Client Message|Sun Nov 20 16:32:39 2016|netcap|42657|localhost:55555 < 127.0.0.1:64851|udp|192.168.0.45 > 104.20.65.243:80|0|64:652:1479684759:35314|tcp:PSH/ACK:24|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12
-Client Message|Sun Nov 20 16:32:39 2016|netcap|42657|localhost:55555 < 127.0.0.1:64851|udp|192.168.0.45 > 104.20.65.243:443|0|64:875:1479684759:234384|tcp:PSH/ACK:24|PU_continent_code|PU_country_code3|PU_country_name|PU_city|PU_region_name|PU_postal_code|PU_latitude|PU_longitude|PU_time_zone|PU_area_code|PU_metro_code|192.168.0.0|192.168.255.255|255.255.0.0|192.168.0.0/16|NA|USA|United States|San Francisco|California|94107|37.7697|-122.3933|America/Los_Angeles|415|807|104.16.0.0|104.31.255.255|255.240.0.0|104.16.0.0/12
+Server Running|Wed Nov 23 18:43:46 2016|netcap|10775|localhost:55555|udp
+Client Message|Wed Nov 23 18:43:59 2016|netcap|10775|localhost:55555 < 127.0.0.1:55313|udp|192.168.0.45 > 104.20.66.243:80|RECORD|0|HEADER|64:627:1479951839:174999|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
+
+-- Reached packet cache limit of 1 (server pid: 10775).
+Current records cached: 1
+Checking /netcap/var/cache.txt for existence of data... Yes.
+Reading and merging with existing cache... done.
+Writing cache to /netcap/var/cache.txt... done.
+Records (unique/total): 8/14
+Building notification... done.
+Refreshing server... done.
+
+Client Message|Wed Nov 23 18:43:59 2016|netcap|10775|localhost:55555 < 127.0.0.1:55313|udp|192.168.0.45 > 104.20.65.243:443|RECORD|0|HEADER|64:891:1479951839:362970|FLAG|tcp:PSH/ACK:24|SRC_CONTINENT_CODE|PU_NULL|SRC_COUNTRY_CODE3|PU_NULL|SRC_COUNTRY_NAME|PU_NULL|SRC_CITY|PU_NULL|SRC_REGION_NAME|PU_NULL|SRC_POSTAL_CODE|PU_NULL|SRC_LATITUDE|PU_NULL|SRC_LONGITUDE|PU_NULL|SRC_TIME_ZONE|PU_NULL|SRC_AREA_CODE|PU_NULL|SRC_METRO_CODE|PU_NULL|SRC_IP4_MIN|192.168.0.0|SRC_IP4_MAX|192.168.255.255|SRC_IP4_MASK|255.255.0.0|SRC_IP4_CIDR|192.168.0.0/16|DST_CONTINENT_CODE|NA|DST_COUNTRY_CODE3|USA|DST_COUNTRY_NAME|United States|DST_CITY|San Francisco|DST_REGION_NAME|California|DST_POSTAL_CODE|94107|DST_LATITUDE|37.7697|DST_LONGITUDE|-122.3933|DST_TIME_ZONE|America/Los_Angeles|DST_AREA_CODE|415|DST_METRO_CODE|807|DST_IP4_MIN|104.16.0.0|DST_IP4_MAX|104.31.255.255|DST_IP4_MASK|255.240.0.0|DST_IP4_CIDR|104.16.0.0/12
+
+-- Reached packet cache limit of 1 (server pid: 10775).
+Current records cached: 1
+Checking /netcap/var/cache.txt for existence of data... Yes.
+Reading and merging with existing cache... done.
+Writing cache to /netcap/var/cache.txt... done.
+Records (unique/total): 8/29
+Building notification... done.
+Refreshing server... done.
+...[OTHER SERVER SIDE CACHE REFRESHES OMITTED]...
 
 In the above, we can see TWO unique events for the server. One for port 80 and 
-one for port 443. Also, note the GEO DB data returned (see CLIENT section for 
-what the "PU" prefix means for the IP of 192.168.0.45 in the event).
+one for port 443. Since we specified a packet count of one, the server cache 
+was refreshed after the first packet (the one for port 80). Since we also told 
+the server to notify, it generates a notification file. Then another packet was 
+received (this one for port 443). The packet count limit of one is once again 
+reached so the server refreshes its cache and generates another notification.  
+
+Also, take note of the GEO information retuned for the source traffic and what 
+the "PU" prefix means for the IP of 192.168.0.45 in the event. Meanwhile, the 
+destination GEO information is returned as requested.
+
+IMPORTANT: It is NOT advised to use --packet-count with such a small integer 
+value on the server side if the traffic being captured is not leveraging a 
+filter (--compile-filter, --regex) to scope traffic or using the --unique 
+option to limit traffic.
 
 Useful commands/options when monitoring are:
 	
@@ -852,7 +1034,7 @@ Note:
 - You MUST capture in order to use netcap's learn mode but you do not 
 have to have a learn file to monitor. You will be warned when starting 
 a netcap client. Proceed at your own risk.
-- See ./netcap --help for more information for monitor mode options.
+- See netcap --help for more information for monitor mode options.
 
 ===========================================================================
 
@@ -865,7 +1047,7 @@ INSTALL.txt if necessary.
 
 1. Test install of netcap
 
-./netcap --help
+netcap --help
 
 Expected output: 
 	- The netcap help menu is outputted to stderr
@@ -875,7 +1057,7 @@ Unexpected output:
 2. Test capture mode (elevated privileges may be required)
 ** Split on multiple lines for readability 
 
-./netcap --interface <device> --capture --packet-count 10 --unique --stdout \
+netcap --interface <device> --capture --packet-count 10 --unique --stdout \
 --capture-file </path/to/capture-file>
 
 Expected output: 
@@ -885,14 +1067,14 @@ Unexpected output:
 	- Make sure you are root before capturing traffic
 	- Make sure a valid device is defined for the netcap --interface 
 	option. If in doubt of the available interfaces that can be 
-	captured from, run: sudo ./netcap --list-interfaces
+	captured from, run: sudo netcap --list-interfaces
 	- Ensure there is traffic on the interface to capture (you 
 	can use a tool like "tcpdump", "nmap", or "nc" to test)
 
 3. Test learn mode 
 ** Split on multiple lines for readability 
 
-./netcap --learn --capture-file </path/to/capture-file> --learn-file \
+netcap --learn --capture-file </path/to/capture-file> --learn-file \
 </path/to/learn-file>
 
 Expected output: 
@@ -939,7 +1121,7 @@ as it contains other documentation.
 5a. Start server (NON daemon)
 ** Split on multiple lines for readability 
 
-./netcap --monitor --server <host> <port> --notify out=<path/to/notify-file> \
+netcap --monitor --server <host> <port> --notify out=<path/to/notify-file> \
 --cache-file </path/to/cache-file> --cache-key-dst --log=server \
 </path/to/server-log-file> --stdout --packet-count 10
 
@@ -957,7 +1139,7 @@ Unexpected output:
 5b. Start client (NON daemon)
 ** Split on multiple lines for readability 
 
-./netcap --monitor --client <host> <port> --interface <device> --promiscuous \
+netcap --monitor --client <host> <port> --interface <device> --promiscuous \
 --learn-file </path/to/learn-file> --log=client out=<path/to/client-log-file> \
 --packet-count 1000 --unique --stdout
 
@@ -972,7 +1154,7 @@ Unexpected output:
 	- Make sure <host> and <port> are valid
 	- Make sure a valid device is defined for the netcap --interface 
 	option. If in doubt of the available interfaces that can be 
-	captured from, run: sudo ./netcap --list-interfaces
+	captured from, run: sudo netcap --list-interfaces
 	- Make sure you have a netcap server running
 	- If you specified --packet-count and the client stopped because the 
 	number of packets were reached, increase the packet limit or omit the 
@@ -985,7 +1167,7 @@ the below commands:
 Server:
 ** Split on multiple lines for readability 
 
-./netcap --monitor --server <host> <port> --notify out=<path/to/notify-file> \
+netcap --monitor --server <host> <port> --notify out=<path/to/notify-file> \
 --cache-file </path/to/cache-file> --cache-key-dst --log=server \
 </path/to/server-log-file> --packet-count <count> --daemon
 
@@ -999,7 +1181,7 @@ the running processes to find it
 Client:
 ** Split on multiple lines for readability 
 
-./netcap --monitor --client <host> <port> --interface <device> --promiscuous \
+netcap --monitor --client <host> <port> --interface <device> --promiscuous \
 --learn-file </path/to/learn-file> --log=client out=<path/to/client-log-file> \
 --packet-count 1000 --unique --daemon
 
@@ -1040,7 +1222,7 @@ Unexpected output:
 	- Make sure <host> and <port> are valid
 	- Make sure a valid device is defined for the netcap --interface 
 	option. If in doubt of the available interfaces that can be 
-	captured from, run: sudo ./netcap --list-interfaces
+	captured from, run: sudo netcap --list-interfaces
 	- Make sure you have a netcap server running
 
 8. Test refresh client/server script (elevated privileges may be required)


### PR DESCRIPTION
Formatted headers for stdout/logs
Fixed bug introduced into server (client) code when --unique specified (packets sent to server regardless of whether they existed in $data{$packet})